### PR TITLE
Add information on how to update the database

### DIFF
--- a/Documentation/Contribution/LocalEnvironment/Ddev/Index.rst
+++ b/Documentation/Contribution/LocalEnvironment/Ddev/Index.rst
@@ -120,6 +120,8 @@ As there are no backend users in the dump, you need to setup a local admin accou
 
 #. `ddev ssh`
 
+#. `../bin/typo3cms database:updateschema` to update the database because the dump included in the assets you downloaded is missing some tables like sys_domain or caching related ones. 
+
 #. `../bin/typo3cms backend:createadmin` and set your username and password in the prompt. (You may need to call one of the scripts directly in the given directory, f.e. `php typo3-console.php backend:createadmin 
 
 


### PR DESCRIPTION
Some tables in the database are missing. To get typo3 up and running you need to update the database using typo3_console