### PR TITLE
[TASK] Fix documentation formatting, consistency, and accuracy issues

### DIFF
--- a/Documentation/FAQ/Index.rst
+++ b/Documentation/FAQ/Index.rst
@@ -25,6 +25,7 @@ A: No, most projects only require standard GitLab access. However, **extensions.
 
 **Q: Which branch should I work on?**
 A: For all projects, work in feature branches created from:
+
 - ``develop`` branch for website projects
 - ``master`` branch for extensions
 
@@ -50,6 +51,7 @@ A: Use the sync command, but be careful as it replaces your entire database::
 
 **Q: Can I access the backend after database sync?**
 A: Yes, a backend user is automatically created:
+
 - Username: ``admin``
 - Password: ``password``
 
@@ -69,6 +71,7 @@ A: LDAP login is disabled in local development due to data protection issues. Cr
 
 **Q: My GitLab authentication fails**
 A: Check your ``auth.json`` file configuration:
+
 1. Ensure the file exists (copy from ``auth.json.example``)
 2. Verify both ``http-basic`` and ``gitlab-api`` sections are configured
 3. Check that username/password and username/token match your GitLab account
@@ -76,6 +79,7 @@ A: Check your ``auth.json`` file configuration:
 
 **Q: What's the difference between http-basic and gitlab-api in auth.json?**
 A: Both sections serve different purposes:
+
 - ``http-basic``: Username/password for basic Git operations (clone, pull, push)
 - ``gitlab-api``: Username/token for API access (database downloads, CI/CD artifacts)
 
@@ -87,6 +91,7 @@ Database & Content
 
 **Q: Where do I get the database dump?**
 A: Database dumps are available via GitLab CI/CD artifacts:
+
 - **typo3.org**: ``https://git.typo3.org/api/v4/projects/5/jobs/artifacts/develop/download?job=Get%20dump%20for%20local%20environment``
 - **Other projects**: URLs will be provided later
 
@@ -95,6 +100,7 @@ A: This is normal. The filefill extension loads assets on-demand from production
 
 **Q: How does filefill work?**
 A: When a file is requested that doesn't exist locally, filefill:
+
 1. Checks configured production domains
 2. Downloads the file from production
 3. Serves it locally for future requests
@@ -112,6 +118,7 @@ A: Use Composer::
 
 **Q: Where are the frontend templates?**
 A: Templates are in the ``t3olayout`` extension:
+
 - t3olayout extension: ``vendor/t3o/t3olayout/``
 - Project-specific extensions: ``extensions/`` directory
 - Vendor extensions: ``vendor/`` directory
@@ -127,6 +134,7 @@ A: Enable debug mode in your ``additional.php``::
 
 **Q: Frontend assets are not building**
 A: Try these steps:
+
 1. Check Node.js version: ``ddev exec node --version`` (should be 14.x) or ``node --version`` for manual setup
 2. Clear npm cache: ``ddev exec npm cache clear --force``
 3. Remove node_modules: ``rm -rf vendor/t3o/t3olayout/Build/node_modules``
@@ -134,6 +142,7 @@ A: Try these steps:
 
 **Q: Wrong Node.js version error**
 A: Frontend assets require Node.js 14:
+
 - **DDEV**: Node.js 14 is included automatically
 - **Manual setup**: Install Node.js 14 from https://nodejs.org/
 
@@ -142,18 +151,21 @@ Project-Specific Issues
 
 **Q: Solr is not working for extensions.typo3.org**
 A: For DDEV environments:
+
 1. Solr should start automatically
 2. Check Solr admin at port 8983
 3. Verify Solr core configuration in TYPO3 backend
 
 **Q: How do I access the TER (extensions.typo3.org) project?**
 A: You need:
+
 1. Standard GitLab access
 2. **Signed NDA** due to GDPR compliance
 3. Contact project maintainers for the NDA process
 
 **Q: What if I need help with a specific project?**
 A: Each project has its own documentation:
+
 - :doc:`../Projects/Typo3Org/Index`
 - :doc:`../Projects/ExtensionsTypo3Org/Index`
 - :doc:`../Projects/VotingTypo3Org/Index`
@@ -164,6 +176,7 @@ Performance & Optimization
 
 **Q: My local environment is slow**
 A: Try these optimizations:
+
 1. Allocate more memory to Docker
 2. Use Docker Desktop's filesystem optimization
 3. Disable unnecessary services
@@ -171,12 +184,14 @@ A: Try these optimizations:
 
 **Q: How do I optimize images?**
 A: Use appropriate formats:
+
 - WebP for modern browsers
 - Optimize file sizes before upload
 - Use responsive images when possible
 
 **Q: Database operations are slow**
 A: Check:
+
 1. Database indexes
 2. Query optimization
 3. Available memory
@@ -187,6 +202,7 @@ Common Error Messages
 
 **Q: "Could not connect to database"**
 A: Check your database configuration in ``additional.php``:
+
 - Verify hostname, username, password
 - Ensure database exists
 - Check database server is running
@@ -208,7 +224,7 @@ A: Check file permissions::
 
     # For DDEV
     ddev exec chown -R www-data:www-data /var/www/html/
-    
+
     # For manual setup
     chown -R www-data:www-data html/
 
@@ -217,6 +233,7 @@ Development Workflow
 
 **Q: How do I create a merge request?**
 A: Follow the :doc:`../Workflow/Index`:
+
 1. Create issue or find existing one
 2. Create branch from GitLab interface
 3. Work locally on the branch
@@ -224,6 +241,7 @@ A: Follow the :doc:`../Workflow/Index`:
 
 **Q: What coding standards should I follow?**
 A: Follow TYPO3 Core coding standards:
+
 - PSR-12 for PHP
 - TYPO3 CGL (Coding Guidelines)
 - Use meaningful commit messages
@@ -231,6 +249,7 @@ A: Follow TYPO3 Core coding standards:
 
 **Q: How do I test my changes?**
 A: Test locally:
+
 1. Verify functionality works
 2. Check responsive design
 3. Test in different browsers
@@ -240,16 +259,19 @@ Still Need Help?
 ================
 
 **Resources**
+
 - TYPO3 Slack: #typo3-org channel
 - TYPO3 Documentation: https://docs.typo3.org/
 - DDEV Documentation: https://ddev.readthedocs.io/
 
 **Contacts**
+
 - Thomas Löffler (@spoonerweb): General T3O questions
 - Project maintainers: Check individual project repositories
 - Community: TYPO3 Slack channels
 
 **Reporting Issues**
+
 - Use project-specific issue trackers
 - Provide detailed error messages
 - Include steps to reproduce

--- a/Documentation/FAQ/Index.rst
+++ b/Documentation/FAQ/Index.rst
@@ -34,7 +34,7 @@ A: For all projects, work in feature branches created from:
 
 **Q: How do I contact the T3O team?**
 
-A: Contact Thomas Löffler (@spoonerweb) in TYPO3 Slack or use the #typo3-org channel.
+A: Contact Thomas Löffler (@spoonerweb) in TYPO3 Slack or use the #t3o-team channel.
 
 DDEV Environment
 ================
@@ -295,7 +295,7 @@ Still Need Help?
 
 **Resources**
 
-- TYPO3 Slack: #typo3-org channel
+- TYPO3 Slack: #t3o-team or #t3o-ter-team channel
 - TYPO3 Documentation: https://docs.typo3.org/
 - DDEV Documentation: https://ddev.readthedocs.io/
 

--- a/Documentation/FAQ/Index.rst
+++ b/Documentation/FAQ/Index.rst
@@ -106,7 +106,7 @@ Database & Content
 
 A: Database dumps are available via GitLab CI/CD artifacts:
 
-- **typo3.org**: ``https://git.typo3.org/api/v4/projects/5/jobs/artifacts/develop/download?job=Get%20dump%20for%20local%20environment``
+- **typo3.org**: ``https://git.typo3.org/api/v4/projects/133/jobs/artifacts/develop/download?job=Get%20dump%20for%20local%20environment``
 - **Other projects**: URLs will be provided later
 
 **Q: Why are images not loading?**
@@ -156,17 +156,17 @@ A: Enable debug mode in your ``additional.php``::
 
 A: Try these steps:
 
-1. Check Node.js version: ``ddev exec node --version`` (should be 14.x) or ``node --version`` for manual setup
+1. Check Node.js version: ``ddev exec node --version`` (should be 18.x or higher) or ``node --version`` for manual setup
 2. Clear npm cache: ``ddev exec npm cache clear --force``
 3. Remove node_modules: ``rm -rf vendor/t3o/t3olayout/Build/node_modules``
 4. Rebuild: ``ddev build-frontend``
 
 **Q: Wrong Node.js version error**
 
-A: Frontend assets require Node.js 14:
+A: Frontend assets require Node.js 18 LTS or higher:
 
-- **DDEV**: Node.js 14 is included automatically
-- **Manual setup**: Install Node.js 14 from https://nodejs.org/
+- **DDEV**: Node.js 18 is included automatically
+- **Manual setup**: Install Node.js 18 LTS from https://nodejs.org/
 
 Project-Specific Issues
 =======================

--- a/Documentation/FAQ/Index.rst
+++ b/Documentation/FAQ/Index.rst
@@ -18,30 +18,36 @@ Getting Started
 ===============
 
 **Q: How do I get access to the TYPO3.org repositories?**
+
 A: You need a TYPO3.org account that corresponds to your GitLab username. Manage your account at `my.typo3.org <https://my.typo3.org/>`_. If you can't access GitLab, log in to https://typo3.org/ once to sync your account with LDAP.
 
 **Q: Do I need special permissions for all projects?**
+
 A: No, most projects only require standard GitLab access. However, **extensions.typo3.org (TER) requires a signed NDA** due to GDPR compliance (user data protection).
 
 **Q: Which branch should I work on?**
+
 A: For all projects, work in feature branches created from:
 
 - ``develop`` branch for website projects
 - ``master`` branch for extensions
 
 **Q: How do I contact the T3O team?**
+
 A: Contact Thomas Löffler (@spoonerweb) in TYPO3 Slack or use the #typo3-org channel.
 
 DDEV Environment
 ================
 
 **Q: DDEV start fails with npm processes error**
+
 A: Remove the ``node_modules`` folder and clear npm cache::
 
     rm -rf vendor/t3o/t3olayout/Build/node_modules
     ddev exec npm cache clear --force
 
 **Q: How do I update my local database?**
+
 A: Use the sync command, but be careful as it replaces your entire database::
 
     ddev sync-database
@@ -50,26 +56,31 @@ A: Use the sync command, but be careful as it replaces your entire database::
    This command will **replace** your existing database with the latest dump. Any local changes will be lost.
 
 **Q: Can I access the backend after database sync?**
+
 A: Yes, a backend user is automatically created:
 
 - Username: ``admin``
 - Password: ``password``
 
 **Q: How do I compile frontend assets?**
+
 A: Use the build command::
 
     ddev build-frontend
 
 **Q: Where can I access Mailpit for testing emails?**
+
 A: Mailpit is available at: https://[your-project].ddev.site:8026
 
 Authentication & Access
 =======================
 
 **Q: Why can't I login with my LDAP user in the frontend?**
+
 A: LDAP login is disabled in local development due to data protection issues. Create a local frontend user instead through the backend.
 
 **Q: My GitLab authentication fails**
+
 A: Check your ``auth.json`` file configuration:
 
 1. Ensure the file exists (copy from ``auth.json.example``)
@@ -78,27 +89,32 @@ A: Check your ``auth.json`` file configuration:
 4. Verify the personal access token is not expired
 
 **Q: What's the difference between http-basic and gitlab-api in auth.json?**
+
 A: Both sections serve different purposes:
 
 - ``http-basic``: Username/password for basic Git operations (clone, pull, push)
 - ``gitlab-api``: Username/token for API access (database downloads, CI/CD artifacts)
 
 **Q: How do I get a GitLab token?**
+
 A: Go to GitLab → User Settings → Access Tokens → Create a token with ``read_repository`` and ``read_api`` permissions.
 
 Database & Content
 ==================
 
 **Q: Where do I get the database dump?**
+
 A: Database dumps are available via GitLab CI/CD artifacts:
 
 - **typo3.org**: ``https://git.typo3.org/api/v4/projects/5/jobs/artifacts/develop/download?job=Get%20dump%20for%20local%20environment``
 - **Other projects**: URLs will be provided later
 
 **Q: Why are images not loading?**
+
 A: This is normal. The filefill extension loads assets on-demand from production servers. Images will appear when requested. Check your filefill configuration if images consistently fail to load.
 
 **Q: How does filefill work?**
+
 A: When a file is requested that doesn't exist locally, filefill:
 
 1. Checks configured production domains
@@ -106,17 +122,20 @@ A: When a file is requested that doesn't exist locally, filefill:
 3. Serves it locally for future requests
 
 **Q: My local changes to content are lost after database sync**
+
 A: This is expected behavior. The ``ddev sync-database`` command replaces your entire database with the production dump. Make content changes in the backend after sync, or work on template/code changes instead.
 
 Extensions & Development
 ========================
 
 **Q: How do I install additional extensions?**
+
 A: Use Composer::
 
     composer require typo3/cms-extension-name
 
 **Q: Where are the frontend templates?**
+
 A: Templates are in the ``t3olayout`` extension:
 
 - t3olayout extension: ``vendor/t3o/t3olayout/``
@@ -124,6 +143,7 @@ A: Templates are in the ``t3olayout`` extension:
 - Vendor extensions: ``vendor/`` directory
 
 **Q: How do I debug TYPO3 issues?**
+
 A: Enable debug mode in your ``additional.php``::
 
     'SYS' => [
@@ -133,6 +153,7 @@ A: Enable debug mode in your ``additional.php``::
     ],
 
 **Q: Frontend assets are not building**
+
 A: Try these steps:
 
 1. Check Node.js version: ``ddev exec node --version`` (should be 14.x) or ``node --version`` for manual setup
@@ -141,6 +162,7 @@ A: Try these steps:
 4. Rebuild: ``ddev build-frontend``
 
 **Q: Wrong Node.js version error**
+
 A: Frontend assets require Node.js 14:
 
 - **DDEV**: Node.js 14 is included automatically
@@ -150,6 +172,7 @@ Project-Specific Issues
 =======================
 
 **Q: Solr is not working for extensions.typo3.org**
+
 A: For DDEV environments:
 
 1. Solr should start automatically
@@ -157,6 +180,7 @@ A: For DDEV environments:
 3. Verify Solr core configuration in TYPO3 backend
 
 **Q: How do I access the TER (extensions.typo3.org) project?**
+
 A: You need:
 
 1. Standard GitLab access
@@ -164,6 +188,7 @@ A: You need:
 3. Contact project maintainers for the NDA process
 
 **Q: What if I need help with a specific project?**
+
 A: Each project has its own documentation:
 
 - :doc:`../Projects/Typo3Org/Index`
@@ -175,6 +200,7 @@ Performance & Optimization
 ===========================
 
 **Q: My local environment is slow**
+
 A: Try these optimizations:
 
 1. Allocate more memory to Docker
@@ -183,6 +209,7 @@ A: Try these optimizations:
 4. Check database query performance
 
 **Q: How do I optimize images?**
+
 A: Use appropriate formats:
 
 - WebP for modern browsers
@@ -190,6 +217,7 @@ A: Use appropriate formats:
 - Use responsive images when possible
 
 **Q: Database operations are slow**
+
 A: Check:
 
 1. Database indexes
@@ -201,6 +229,7 @@ Common Error Messages
 =====================
 
 **Q: "Could not connect to database"**
+
 A: Check your database configuration in ``additional.php``:
 
 - Verify hostname, username, password
@@ -208,6 +237,7 @@ A: Check your database configuration in ``additional.php``:
 - Check database server is running
 
 **Q: "Trusted hosts pattern mismatch"**
+
 A: Add this to your ``additional.php``::
 
     'SYS' => [
@@ -215,11 +245,13 @@ A: Add this to your ``additional.php``::
     ],
 
 **Q: "Extension not found"**
+
 A: Run::
 
     composer install
 
 **Q: "Permission denied" errors**
+
 A: Check file permissions::
 
     # For DDEV
@@ -232,6 +264,7 @@ Development Workflow
 ====================
 
 **Q: How do I create a merge request?**
+
 A: Follow the :doc:`../Workflow/Index`:
 
 1. Create issue or find existing one
@@ -240,6 +273,7 @@ A: Follow the :doc:`../Workflow/Index`:
 4. Push changes and create merge request
 
 **Q: What coding standards should I follow?**
+
 A: Follow TYPO3 Core coding standards:
 
 - PSR-12 for PHP
@@ -248,6 +282,7 @@ A: Follow TYPO3 Core coding standards:
 - Write tests for new functionality
 
 **Q: How do I test my changes?**
+
 A: Test locally:
 
 1. Verify functionality works

--- a/Documentation/LocalEnvironment/Ddev/Index.rst
+++ b/Documentation/LocalEnvironment/Ddev/Index.rst
@@ -18,11 +18,13 @@ Prerequisites
 =============
 
 **Required Software**
+
 - Docker: `Download Docker <https://www.docker.com/community-edition#/download>`_
 - DDEV: `Installation Guide <https://ddev.readthedocs.io/en/latest/#installation>`_
 - Node.js 14: Required for frontend asset building (automatically available in DDEV)
 
 **Access Requirements**
+
 - GitLab account corresponding to your TYPO3.org username
 - For TER project: Signed NDA required due to GDPR compliance
 
@@ -69,6 +71,7 @@ Clone Repository
     }
 
    **Required fields:**
+
    - ``http-basic``: Basic authentication for Git operations
    - ``gitlab-api``: API access for database synchronization
    - ``project-id``: Project ID for database dumps (varies by project)
@@ -156,11 +159,13 @@ Solr Integration
 For projects requiring Solr search (like extensions.typo3.org):
 
 **Built-in Solr Server**
+
 - Solr runs automatically in a Docker container
 - Access Solr Admin: https://[your-project].ddev.site:8983
 - No additional configuration needed
 
 **Usage**
+
 - The Solr server is pre-configured and ready to use
 - Indexes are automatically created during database import
 

--- a/Documentation/LocalEnvironment/Ddev/Index.rst
+++ b/Documentation/LocalEnvironment/Ddev/Index.rst
@@ -184,5 +184,5 @@ Getting Help
 ============
 
 - Check the :doc:`../../FAQ/Index` for more solutions
-- Ask in TYPO3 Slack #typo3-org channel
+- Ask in TYPO3 Slack #t3o-team or #t3o-ter-team channel
 - Review DDEV documentation: https://ddev.readthedocs.io/

--- a/Documentation/LocalEnvironment/Ddev/Index.rst
+++ b/Documentation/LocalEnvironment/Ddev/Index.rst
@@ -19,9 +19,9 @@ Prerequisites
 
 **Required Software**
 
-- Docker: `Download Docker <https://www.docker.com/community-edition#/download>`_
+- Docker: `Download Docker Desktop <https://www.docker.com/products/docker-desktop/>`_
 - DDEV: `Installation Guide <https://ddev.readthedocs.io/en/latest/#installation>`_
-- Node.js 14: Required for frontend asset building (automatically available in DDEV)
+- Node.js 18 LTS: Required for frontend asset building (automatically available in DDEV)
 
 **Access Requirements**
 
@@ -120,14 +120,14 @@ Frontend Development
 CSS and JavaScript Assets
 --------------------------
 
-To work on frontend assets (uses Node.js 14 automatically)::
+To work on frontend assets (uses Node.js 18 automatically)::
 
     ddev build-frontend
 
 This command compiles all CSS and JavaScript files needed for the frontend.
 
 **Node.js Version in DDEV**
-DDEV containers include Node.js 14 by default. You can verify this::
+DDEV containers include Node.js 18 by default. You can verify this::
 
     ddev exec node --version
 
@@ -184,5 +184,5 @@ Getting Help
 ============
 
 - Check the :doc:`../../FAQ/Index` for more solutions
-- Ask in TYPO3 Slack #t3o-team or #t3o-ter-team channel
+- Ask in TYPO3 Slack #typo3-org channel
 - Review DDEV documentation: https://ddev.readthedocs.io/

--- a/Documentation/LocalEnvironment/Ddev/Index.rst
+++ b/Documentation/LocalEnvironment/Ddev/Index.rst
@@ -50,25 +50,11 @@ Clone Repository
 
     cp auth.json.example auth.json
 
-#. Edit ``auth.json`` and add your GitLab credentials::
+#. Edit ``auth.json`` and add your GitLab credentials:
 
-    {
-        "http-basic": {
-            "git.typo3.org": {
-                "username": "gitlabusername",
-                "password": "gitlabpassword"
-            }
-        },
-        "gitlab-api": {
-            "git.typo3.org": {
-                "username": "gitlabusername",
-                "token": "gitlab_personal_access_token",
-                "project-id": "133",
-                "branch": "main",
-                "job-name": "Get dump for local environment"
-            }
-        }
-    }
+   ..  literalinclude:: ../_codesnippets/auth.json
+       :caption: auth.json
+       :language: json
 
    **Required fields:**
 

--- a/Documentation/LocalEnvironment/Index.rst
+++ b/Documentation/LocalEnvironment/Index.rst
@@ -4,7 +4,7 @@
 .. _local-environment:
 
 =================
-Local Environment
+Local environment
 =================
 
 .. contents:: On this page:
@@ -14,7 +14,7 @@ Local Environment
 
 This section covers setting up a local development environment for TYPO3.org projects.
 
-Setup Options
+Setup options
 =============
 
 Choose your preferred setup method:
@@ -63,7 +63,7 @@ Both setup methods provide complete local development environments for TYPO3.org
   - Source files located in ``vendor/t3o/t3olayout/Build/``
   - Automated building (DDEV) or manual npm commands (Manual setup)
 
-Next Steps
+Next steps
 ==========
 
 - **New to DDEV?** → :doc:`Ddev/Index`

--- a/Documentation/LocalEnvironment/Index.rst
+++ b/Documentation/LocalEnvironment/Index.rst
@@ -59,7 +59,7 @@ Both setup methods provide complete local development environments for TYPO3.org
 **Frontend Asset Building**
   CSS and JavaScript compilation for development:
   
-  - Node.js 14 required for asset compilation
+  - Node.js 18 LTS required for asset compilation
   - Source files located in ``vendor/t3o/t3olayout/Build/``
   - Automated building (DDEV) or manual npm commands (Manual setup)
 

--- a/Documentation/LocalEnvironment/Manual/Index.rst
+++ b/Documentation/LocalEnvironment/Manual/Index.rst
@@ -239,5 +239,5 @@ Getting Help
 ============
 
 - Check the :doc:`../../FAQ/Index` for more solutions
-- Ask in TYPO3 Slack #typo3-org channel
+- Ask in TYPO3 Slack #t3o-team or #t3o-ter-team channel
 - Review TYPO3 documentation: https://docs.typo3.org/

--- a/Documentation/LocalEnvironment/Manual/Index.rst
+++ b/Documentation/LocalEnvironment/Manual/Index.rst
@@ -18,6 +18,7 @@ Prerequisites
 =============
 
 **Web Server Requirements**
+
 - PHP 8.1 or higher
 - MariaDB or MySQL database
 - Web server (Apache/Nginx)
@@ -25,9 +26,11 @@ Prerequisites
 - All TYPO3 12.4 LTS requirements
 
 **Optional for TER Project**
+
 - Solr Server 6.6 (for extensions.typo3.org search functionality)
 
 **Access Requirements**
+
 - GitLab account corresponding to your TYPO3.org username
 - For TER project: Signed NDA required due to GDPR compliance
 
@@ -72,6 +75,7 @@ Clone Repository
     }
 
    **Required fields:**
+
    - ``http-basic``: Basic authentication for Git operations
    - ``gitlab-api``: API access for database synchronization and CI/CD artifacts
    - ``project-id``: Project ID for database dumps (5 = typo3.org)
@@ -96,6 +100,7 @@ Database Setup
     mysql -u your-user -p your-database < DB.sql
 
 **Database URLs for Projects:**
+
 - typo3.org: ``https://git.typo3.org/api/v4/projects/5/jobs/artifacts/develop/download?job=Get%20dump%20for%20local%20environment``
 - Other projects: URLs will be provided later
 
@@ -172,6 +177,7 @@ Add filefill configuration to your ``additional.php``::
 This configuration allows the filefill extension to load assets from production servers when they're not available locally.
 
 **Project-specific configurations:**
+
 - typo3.org: Configuration shown above
 - Other projects: Configurations will be provided later
 
@@ -245,6 +251,7 @@ File Assets
 Thanks to the filefill extension by Nicole Cordes, you don't need to download the complete fileadmin directory. Assets are loaded on-demand from production servers.
 
 **How it works:**
+
 - When a file is requested that doesn't exist locally
 - Filefill checks the configured domains
 - Downloads the file from production

--- a/Documentation/LocalEnvironment/Manual/Index.rst
+++ b/Documentation/LocalEnvironment/Manual/Index.rst
@@ -22,7 +22,7 @@ Prerequisites
 - PHP 8.1 or higher
 - MariaDB or MySQL database
 - Web server (Apache/Nginx)
-- Node.js 14 (for frontend asset building)
+- Node.js 18 LTS or higher (for frontend asset building)
 - All TYPO3 12.4 LTS requirements
 
 **Optional for TER Project**
@@ -54,31 +54,17 @@ Clone Repository
 
     cp auth.json.example auth.json
 
-#. Edit ``auth.json`` and add your GitLab credentials::
+#. Edit ``auth.json`` and add your GitLab credentials:
 
-    {
-        "http-basic": {
-            "git.typo3.org": {
-                "username": "gitlabusername",
-                "password": "gitlabpassword"
-            }
-        },
-        "gitlab-api": {
-            "git.typo3.org": {
-                "username": "gitlabusername",
-                "token": "gitlab_personal_access_token",
-                "project-id": "5",
-                "branch": "develop",
-                "job-name": "Get dump for local environment"
-            }
-        }
-    }
+   ..  literalinclude:: ../_codesnippets/auth.json
+       :caption: auth.json
+       :language: json
 
    **Required fields:**
 
    - ``http-basic``: Basic authentication for Git operations
    - ``gitlab-api``: API access for database synchronization and CI/CD artifacts
-   - ``project-id``: Project ID for database dumps (5 = typo3.org)
+   - ``project-id``: Project ID for database dumps (133 = typo3.org, 134 = extensions.typo3.org)
 
 Database Setup
 --------------
@@ -91,7 +77,7 @@ Database Setup
 
     # For typo3.org
     curl -H "PRIVATE-TOKEN: your-gitlab-token" \
-         "https://git.typo3.org/api/v4/projects/5/jobs/artifacts/develop/download?job=Get%20dump%20for%20local%20environment" \
+         "https://git.typo3.org/api/v4/projects/133/jobs/artifacts/develop/download?job=Get%20dump%20for%20local%20environment" \
          -o database.zip
 
 #. Extract and import the database::
@@ -101,7 +87,7 @@ Database Setup
 
 **Database URLs for Projects:**
 
-- typo3.org: ``https://git.typo3.org/api/v4/projects/5/jobs/artifacts/develop/download?job=Get%20dump%20for%20local%20environment``
+- typo3.org: ``https://git.typo3.org/api/v4/projects/133/jobs/artifacts/develop/download?job=Get%20dump%20for%20local%20environment``
 - Other projects: URLs will be provided later
 
 TYPO3 Configuration
@@ -150,7 +136,7 @@ CSS and JavaScript Setup
 
 .. rst-class:: bignums
 
-#. Verify Node.js version (must be Node.js 14)::
+#. Verify Node.js version (must be Node.js 18 LTS or higher)::
 
     node --version
 

--- a/Documentation/LocalEnvironment/Manual/Index.rst
+++ b/Documentation/LocalEnvironment/Manual/Index.rst
@@ -110,69 +110,21 @@ TYPO3 Configuration
 Additional Configuration
 ------------------------
 
-Create ``config/system/additional.php``::
+Create ``config/system/additional.php``:
 
-    <?php
-    
-    $GLOBALS['TYPO3_CONF_VARS'] = array_replace_recursive(
-        $GLOBALS['TYPO3_CONF_VARS'],
-        [
-            'BE' => [
-                'loginRateLimit' => 0,
-                'passwordPolicy' => '',
-            ],
-            'DB' => [
-                'Connections' => [
-                    'Default' => [
-                        'dbname' => 'your_database_name',
-                        'driver' => 'mysqli',
-                        'host' => 'localhost',
-                        'password' => 'your_password',
-                        'port' => '3306',
-                        'user' => 'your_username',
-                    ],
-                ],
-            ],
-            'FE' => [
-                'loginRateLimit' => 0,
-            ],
-            'GFX' => [
-                'processor' => 'ImageMagick',
-                'processor_path' => '/usr/bin/',
-                'processor_path_lzw' => '/usr/bin/',
-            ],
-            'MAIL' => [
-                'transport' => 'sendmail',
-                'transport_sendmail_command' => '/usr/sbin/sendmail -t -i',
-            ],
-            'SYS' => [
-                'trustedHostsPattern' => '.*',
-                'devIPmask' => '*',
-                'displayErrors' => 1,
-            ],
-        ]
-    );
+..  literalinclude:: ../_codesnippets/additional.php
+    :caption: config/system/additional.php
+    :language: php
 
 
 Filefill Configuration
 ======================
 
-Add filefill configuration to your ``additional.php``::
+Add filefill configuration to your ``additional.php``:
 
-    // Filefill configuration for typo3.org
-    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['filefill']['storages'][1] = [
-        [
-            'identifier' => 'domain',
-            'configuration' => 'https://typo3.org/',
-        ],
-        [
-            'identifier' => 'domain',
-            'configuration' => 'https://my.typo3.org/',
-        ],
-        [
-            'identifier' => 'placeholder',
-        ],
-    ];
+..  literalinclude:: ../_codesnippets/filefill.php
+    :caption: Filefill configuration (add to additional.php)
+    :language: php
 
 This configuration allows the filefill extension to load assets from production servers when they're not available locally.
 

--- a/Documentation/LocalEnvironment/_codesnippets/additional.php
+++ b/Documentation/LocalEnvironment/_codesnippets/additional.php
@@ -1,0 +1,40 @@
+<?php
+
+$GLOBALS['TYPO3_CONF_VARS'] = array_replace_recursive(
+    $GLOBALS['TYPO3_CONF_VARS'],
+    [
+        'BE' => [
+            'loginRateLimit' => 0,
+            'passwordPolicy' => '',
+        ],
+        'DB' => [
+            'Connections' => [
+                'Default' => [
+                    'dbname' => 'your_database_name',
+                    'driver' => 'mysqli',
+                    'host' => 'localhost',
+                    'password' => 'your_password',
+                    'port' => '3306',
+                    'user' => 'your_username',
+                ],
+            ],
+        ],
+        'FE' => [
+            'loginRateLimit' => 0,
+        ],
+        'GFX' => [
+            'processor' => 'ImageMagick',
+            'processor_path' => '/usr/bin/',
+            'processor_path_lzw' => '/usr/bin/',
+        ],
+        'MAIL' => [
+            'transport' => 'sendmail',
+            'transport_sendmail_command' => '/usr/sbin/sendmail -t -i',
+        ],
+        'SYS' => [
+            'trustedHostsPattern' => '.*',
+            'devIPmask' => '*',
+            'displayErrors' => 1,
+        ],
+    ]
+);

--- a/Documentation/LocalEnvironment/_codesnippets/auth.json
+++ b/Documentation/LocalEnvironment/_codesnippets/auth.json
@@ -1,0 +1,17 @@
+{
+    "http-basic": {
+        "git.typo3.org": {
+            "username": "gitlabusername",
+            "password": "gitlabpassword"
+        }
+    },
+    "gitlab-api": {
+        "git.typo3.org": {
+            "username": "gitlabusername",
+            "token": "gitlab_personal_access_token",
+            "project-id": "133",
+            "branch": "main",
+            "job-name": "Get dump for local environment"
+        }
+    }
+}

--- a/Documentation/LocalEnvironment/_codesnippets/auth.json
+++ b/Documentation/LocalEnvironment/_codesnippets/auth.json
@@ -10,7 +10,7 @@
             "username": "gitlabusername",
             "token": "gitlab_personal_access_token",
             "project-id": "133",
-            "branch": "main",
+            "branch": "develop",
             "job-name": "Get dump for local environment"
         }
     }

--- a/Documentation/LocalEnvironment/_codesnippets/filefill.php
+++ b/Documentation/LocalEnvironment/_codesnippets/filefill.php
@@ -1,0 +1,14 @@
+// Filefill configuration for typo3.org
+$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['filefill']['storages'][1] = [
+    [
+        'identifier' => 'domain',
+        'configuration' => 'https://typo3.org/',
+    ],
+    [
+        'identifier' => 'domain',
+        'configuration' => 'https://my.typo3.org/',
+    ],
+    [
+        'identifier' => 'placeholder',
+    ],
+];

--- a/Documentation/Projects/ExtensionsTypo3Org/Index.rst
+++ b/Documentation/Projects/ExtensionsTypo3Org/Index.rst
@@ -254,7 +254,7 @@ Getting Help
 
 - Project-specific issues: Repository issue tracker
 - Solr questions: TYPO3 Slack #typo3-solr
-- General questions: TYPO3 Slack #typo3-org
+- General questions: TYPO3 Slack #t3o-ter-team
 
 **Resources**
 

--- a/Documentation/Projects/ExtensionsTypo3Org/Index.rst
+++ b/Documentation/Projects/ExtensionsTypo3Org/Index.rst
@@ -19,7 +19,8 @@ Repository Information
 
 **Repository URL**: https://git.typo3.org/services/t3o-sites/extensions.typo3.org/ter
 
-**Branch Strategy**: 
+**Branch Strategy**:
+
 - Main branch: ``develop``
 - Feature branches: ``feature/issue-number-description``
 
@@ -36,6 +37,7 @@ Project Description
 The TYPO3 Extension Repository provides:
 
 **Core Features**
+
 - Extension registration and management
 - Extension key management (register, transfer, remove)
 - Extension uploads and version management
@@ -45,6 +47,7 @@ The TYPO3 Extension Repository provides:
 - Download statistics and analytics
 
 **Target Audience**
+
 - Extension developers
 - TYPO3 integrators searching for extensions
 - Community members exploring available extensions
@@ -58,6 +61,7 @@ Technical Details
 **Database**: MariaDB
 
 **Key Extensions**
+
 - ``t3olayout``: Common layout and styling
 - ``filefill``: Asset loading from production
 - ``solr``: Search functionality (**required**)
@@ -103,11 +107,13 @@ Local Development Setup
 Follow the :doc:`../../LocalEnvironment/Manual/Index` guide with these additional requirements:
 
 **Solr Server Setup**
+
 - Install Apache Solr 6.6 locally
 - Configure Solr cores for extension indexing
 - Set up Solr connection in TYPO3 backend
 
 **Database and Configuration**
+
 - Database dump: URL will be provided later
 - Filefill configuration: Will be provided later
 
@@ -115,18 +121,22 @@ Solr Configuration
 ==================
 
 **DDEV Environment**
+
 - Solr runs automatically in Docker container
 - Pre-configured for development use
 - Access admin interface at port 8983
 
 **Manual Environment**
+
 - Install Solr 6.6 manually
 - Configure cores for:
+
   - Extension metadata indexing
   - Extension documentation indexing
   - Extension code search (if applicable)
 
 **Solr Features**
+
 - Full-text search in extensions
 - Faceted search by categories, TYPO3 version, etc.
 - Search suggestions and autocomplete
@@ -136,23 +146,27 @@ Development Guidelines
 ======================
 
 **Extension Data Management**
+
 - Extensions are imported from external sources
 - Local changes may be overwritten during imports
 - Focus on frontend/backend functionality rather than data
 
 **Frontend Development**
+
 - Build assets: ``ddev build-frontend`` (DDEV)
 - Special attention to search interface
 - Responsive design for mobile browsing
 - Performance optimization for large datasets
 
 **Search Functionality**
+
 - Test search with various queries
 - Verify faceted search filters
 - Check search result relevance
 - Test autocomplete functionality
 
 **Backend Development**
+
 - Extension management interfaces
 - User management for extension developers
 - Analytics and reporting features
@@ -162,17 +176,20 @@ Common Development Tasks
 ========================
 
 **Working with Extensions**
+
 - Extension data is imported, not manually created
 - Focus on display and search functionality
 - Test with various extension types and sizes
 
 **Search Development**
+
 - Modify search templates and logic
 - Update Solr configuration if needed
 - Test search performance with large datasets
 - Implement new search features
 
 **User Management**
+
 - Extension developer accounts
 - Permission management
 - User registration and verification
@@ -181,24 +198,28 @@ Special Considerations
 ======================
 
 **Data Protection (GDPR)**
+
 - User data handling requires special care
 - Privacy policy compliance
 - Data retention policies
 - User consent management
 
 **Performance**
+
 - Large dataset handling
 - Search performance optimization
 - Caching strategies for extension data
 - Database query optimization
 
 **Security**
+
 - User authentication and authorization
 - Extension upload security
 - Input validation and sanitization
 - Rate limiting for API endpoints
 
 **Import Processes**
+
 - Extension data imports from external sources
 - Automated synchronization processes
 - Data validation and cleanup
@@ -208,12 +229,14 @@ Known Issues & Solutions
 ========================
 
 **Common Problems**
+
 - Solr connection issues → Check Solr server status and configuration
 - Search not working → Verify Solr indexing and core configuration
 - Import failures → Check data sources and import scripts
 - Performance issues → Optimize database queries and caching
 
 **Development Specific**
+
 - Large dataset handling → Use pagination and lazy loading
 - Search relevance → Tune Solr configuration and boost factors
 - Memory issues → Increase PHP memory limit for large operations
@@ -222,15 +245,18 @@ Getting Help
 ============
 
 **⚠️ Access Issues**
+
 - Contact project maintainers for NDA process
 - Ensure your GitLab account matches TYPO3.org username
 
 **Technical Support**
+
 - Project-specific issues: Repository issue tracker
 - Solr questions: TYPO3 Slack #typo3-solr
 - General questions: TYPO3 Slack #typo3-org
 
 **Resources**
+
 - TYPO3 Solr documentation: https://docs.typo3.org/c/typo3/cms-solr/
 - Apache Solr documentation: https://solr.apache.org/guide/
 - Extension development: https://docs.typo3.org/m/typo3/reference-coreapi/

--- a/Documentation/Projects/ExtensionsTypo3Org/Index.rst
+++ b/Documentation/Projects/ExtensionsTypo3Org/Index.rst
@@ -27,6 +27,7 @@ Repository Information
 **Workflow**: Follow the standard :doc:`../../Workflow/Index`
 
 **⚠️ Special Access Requirements**
+
 - **Signed NDA required** due to GDPR compliance (user data protection)
 - Standard GitLab access not sufficient
 - Contact project maintainers for NDA process

--- a/Documentation/Projects/Index.rst
+++ b/Documentation/Projects/Index.rst
@@ -29,7 +29,7 @@ The TYPO3 Organization maintains several web projects, each with its own reposit
 
 .. list-table:: Project Overview
    :header-rows: 1
-   :widths: 25 35 25 15
+   :widths: 20 30 25 15 10
 
    * - Project
      - Repository

--- a/Documentation/Projects/Index.rst
+++ b/Documentation/Projects/Index.rst
@@ -63,17 +63,20 @@ Common Architecture
 All projects share similar architecture:
 
 **Technology Stack**
+
 - TYPO3 CMS 12.4 LTS
 - PHP 8.1+
 - MariaDB/MySQL database
 - Composer for dependency management
 
 **Extensions**
+
 - ``t3olayout``: Common layout extension for all projects
 - ``filefill``: Asset loading from production (by Nicole Cordes)
 - Project-specific extensions as needed
 
 **Development Workflow**
+
 - GitLab-based development
 - Feature branches from ``develop`` branch
 - Merge requests for code review
@@ -85,6 +88,7 @@ Database Synchronization
 Each project provides database dumps via GitLab CI/CD artifacts:
 
 **Available Databases**
+
 - **typo3.org**: ``https://git.typo3.org/api/v4/projects/133/jobs/artifacts/develop/download?job=Get%20dump%20for%20local%20environment``
 - **Other projects**: URLs will be provided later
 
@@ -95,11 +99,13 @@ Access Requirements
 ===================
 
 **Standard Access**
+
 - TYPO3.org account
 - GitLab access (username must match TYPO3.org username)
 - Account management via `my.typo3.org <https://my.typo3.org/>`_
 
 **Special Access Requirements**
+
 - **extensions.typo3.org**: Signed NDA required due to GDPR compliance (user data protection)
 
 If you can't access GitLab, log in to https://typo3.org/ once to sync your account with LDAP.
@@ -131,11 +137,13 @@ Branch Strategy
 ===============
 
 **Website Projects**
+
 - Main branch: ``develop``
 - Feature branches: ``feature/issue-number-description``
 - Hotfix branches: ``hotfix/description``
 
 **Extensions**
+
 - Main branch: ``master``
 - Feature branches: ``feature/issue-number-description``
 

--- a/Documentation/Projects/Index.rst
+++ b/Documentation/Projects/Index.rst
@@ -22,7 +22,7 @@ This section provides an overview of all TYPO3.org projects, their repositories,
    VotingTypo3Org/Index
    MyTypo3Org/Index
 
-Project Overview
+Project overview
 ================
 
 The TYPO3 Organization maintains several web projects, each with its own repository and specific requirements:
@@ -57,7 +57,7 @@ The TYPO3 Organization maintains several web projects, each with its own reposit
      - None
      - None
 
-Common Architecture
+Common architecture
 ===================
 
 All projects share similar architecture:
@@ -82,7 +82,7 @@ All projects share similar architecture:
 - Merge requests for code review
 - CI/CD pipelines for testing and deployment
 
-Database Synchronization
+Database synchronization
 ========================
 
 Each project provides database dumps via GitLab CI/CD artifacts:
@@ -95,7 +95,7 @@ Each project provides database dumps via GitLab CI/CD artifacts:
 **DDEV Integration**
 All projects support the ``ddev sync-database`` command for automated database synchronization.
 
-Access Requirements
+Access requirements
 ===================
 
 **Standard Access**
@@ -110,7 +110,7 @@ Access Requirements
 
 If you can't access GitLab, log in to https://typo3.org/ once to sync your account with LDAP.
 
-Filefill Configuration
+Filefill configuration
 ======================
 
 Each project has specific filefill configuration for asset loading:
@@ -123,7 +123,7 @@ Each project has specific filefill configuration for asset loading:
 
 **Other Projects**: Configurations will be provided later.
 
-Branch Strategy
+Branch strategy
 ===============
 
 **Website Projects**
@@ -137,7 +137,7 @@ Branch Strategy
 - Main branch: ``master``
 - Feature branches: ``feature/issue-number-description``
 
-Getting Started
+Getting started
 ===============
 
 **For New Contributors**
@@ -158,7 +158,7 @@ Getting Started
 #. Review merge requests that need testing
 #. Follow the established :doc:`../Workflow/Index`
 
-Next Steps
+Next steps
 ==========
 
 - **Project Details**: Click on individual projects above for specific information

--- a/Documentation/Projects/Index.rst
+++ b/Documentation/Projects/Index.rst
@@ -115,21 +115,11 @@ Filefill Configuration
 
 Each project has specific filefill configuration for asset loading:
 
-**typo3.org Configuration**::
+**typo3.org Configuration**
 
-    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['filefill']['storages'][1] = [
-        [
-            'identifier' => 'domain',
-            'configuration' => 'https://typo3.org/',
-        ],
-        [
-            'identifier' => 'domain',
-            'configuration' => 'https://my.typo3.org/',
-        ],
-        [
-            'identifier' => 'placeholder',
-        ],
-    ];
+..  literalinclude:: ../LocalEnvironment/_codesnippets/filefill.php
+    :caption: Filefill configuration for typo3.org
+    :language: php
 
 **Other Projects**: Configurations will be provided later.
 

--- a/Documentation/Projects/MyTypo3Org/Index.rst
+++ b/Documentation/Projects/MyTypo3Org/Index.rst
@@ -19,13 +19,15 @@ Repository Information
 
 **Repository URL**: *To be provided*
 
-**Branch Strategy**: 
+**Branch Strategy**:
+
 - Main branch: ``develop``
 - Feature branches: ``feature/issue-number-description``
 
 **Workflow**: Follow the standard :doc:`../../Workflow/Index`
 
 **Access Requirements**
+
 - Standard GitLab access
 - TYPO3.org account required
 
@@ -35,6 +37,7 @@ Project Description
 my.typo3.org serves as the central user management platform providing:
 
 **Core Features**
+
 - User registration for new TYPO3.org users
 - Profile management and editing
 - Basic user data management (name, email, contact information)
@@ -43,6 +46,7 @@ my.typo3.org serves as the central user management platform providing:
 - GitLab account synchronization
 
 **User Data Management**
+
 - First and last name
 - Email address management
 - Contact information
@@ -50,6 +54,7 @@ my.typo3.org serves as the central user management platform providing:
 - Privacy preferences
 
 **Target Audience**
+
 - All TYPO3 community members
 - New users registering for TYPO3.org
 - Existing users managing their profiles
@@ -63,12 +68,14 @@ Technical Details
 **Database**: MariaDB
 
 **Key Extensions**
+
 - ``t3olayout``: Common layout and styling
 - ``filefill``: Asset loading from production
 - Custom user management extensions
 - LDAP integration for authentication
 
 **Special Requirements**
+
 - LDAP connectivity for user authentication
 - Integration with GitLab for account synchronization
 
@@ -109,24 +116,28 @@ Development Guidelines
 ======================
 
 **User Management Development**
+
 - Secure user data handling
 - GDPR compliance for personal data
 - User authentication and authorization
 - Account verification processes
 
 **Frontend Development**
+
 - Build assets: ``ddev build-frontend`` (DDEV)
 - User-friendly profile interfaces
 - Responsive design for all devices
 - Accessibility compliance
 
 **Backend Development**
+
 - User administration interfaces
 - Data export and import functionality
 - Account synchronization systems
 - User activity logging
 
 **Security Considerations**
+
 - Personal data protection
 - Secure authentication mechanisms
 - Data encryption for sensitive information
@@ -136,18 +147,21 @@ Common Development Tasks
 ========================
 
 **User Profile Management**
+
 - Profile creation and editing forms
 - Data validation and sanitization
 - Image upload and management
 - Privacy settings configuration
 
 **Account Administration**
+
 - User account creation and verification
 - Bulk user management operations
 - Account status management
 - User data export/import
 
 **Integration Development**
+
 - GitLab account synchronization
 - LDAP authentication integration
 - Third-party service connections
@@ -157,24 +171,28 @@ Special Considerations
 ======================
 
 **Data Protection (GDPR)**
+
 - Personal data handling compliance
 - User consent management
 - Data retention policies
 - Right to be forgotten implementation
 
 **Security & Privacy**
+
 - Secure password handling
 - Two-factor authentication support
 - Account lockout mechanisms
 - Privacy-by-design principles
 
 **Performance**
+
 - Efficient user data queries
 - Caching for user profiles
 - Optimized authentication processes
 - Database indexing for user searches
 
 **Integration Requirements**
+
 - LDAP server connectivity
 - GitLab API integration
 - Email service integration
@@ -184,12 +202,14 @@ Known Issues & Solutions
 ========================
 
 **Common Problems**
+
 - LDAP connection issues → Check LDAP server configuration
 - GitLab sync failures → Verify API credentials and permissions
 - Email delivery problems → Check email service configuration
 - Authentication loops → Clear cookies and check session handling
 
 **Development Specific**
+
 - User data privacy → Implement proper data handling procedures
 - Database synchronization → Follow user data protection guidelines
 - Local LDAP testing → Use development LDAP server or mock services
@@ -198,16 +218,19 @@ Getting Help
 ============
 
 **Project Support**
+
 - Repository issues: Use project issue tracker (when available)
 - User management questions: TYPO3 Slack #typo3-org
 - LDAP/Authentication: Contact system administrators
 
 **Technical Resources**
+
 - TYPO3 documentation: https://docs.typo3.org/
 - GDPR compliance: https://gdpr.eu/
 - LDAP integration: TYPO3 LDAP extension documentation
 
 **Contacts**
+
 - Project maintainers: To be identified
 - System administrators: For LDAP and infrastructure questions
 
@@ -219,12 +242,14 @@ Development Status
    filefill configuration will be provided once available.
 
 **What's Available**
+
 - Project concept and requirements
 - Technical specifications
 - Development guidelines
 - Integration requirements
 
 **Coming Soon**
+
 - Repository access
 - Database dumps
 - LDAP configuration details
@@ -234,6 +259,7 @@ Community Features
 ==================
 
 **Planned Features**
+
 - Community member directory
 - Group and team management
 - Event participation tracking
@@ -241,6 +267,7 @@ Community Features
 - Community badges and achievements
 
 **Integration Points**
+
 - TYPO3.org main site integration
 - Extension repository user linking
 - Voting platform authentication

--- a/Documentation/Projects/MyTypo3Org/Index.rst
+++ b/Documentation/Projects/MyTypo3Org/Index.rst
@@ -220,7 +220,7 @@ Getting Help
 **Project Support**
 
 - Repository issues: Use project issue tracker (when available)
-- User management questions: TYPO3 Slack #typo3-org
+- User management questions: TYPO3 Slack #t3o-team
 - LDAP/Authentication: Contact system administrators
 
 **Technical Resources**

--- a/Documentation/Projects/Typo3Org/Index.rst
+++ b/Documentation/Projects/Typo3Org/Index.rst
@@ -182,7 +182,7 @@ Getting Help
 **Resources**
 
 - Project-specific issues: Repository issue tracker
-- General questions: TYPO3 Slack #typo3-org
+- General questions: TYPO3 Slack #t3o-team
 - TYPO3 documentation: https://docs.typo3.org/
 
 **Contacts**

--- a/Documentation/Projects/Typo3Org/Index.rst
+++ b/Documentation/Projects/Typo3Org/Index.rst
@@ -92,7 +92,7 @@ Local Development Setup
 
 Follow the :doc:`../../LocalEnvironment/Manual/Index` guide with these project-specific details:
 
-- Database dump: ``https://git.typo3.org/api/v4/projects/5/jobs/artifacts/develop/download?job=Get%20dump%20for%20local%20environment``
+- Database dump: ``https://git.typo3.org/api/v4/projects/133/jobs/artifacts/develop/download?job=Get%20dump%20for%20local%20environment``
 - Filefill configuration: See the configuration in :doc:`../../LocalEnvironment/Ddev/Index`
 
 Development Guidelines

--- a/Documentation/Projects/Typo3Org/Index.rst
+++ b/Documentation/Projects/Typo3Org/Index.rst
@@ -19,7 +19,8 @@ Repository Information
 
 **Repository URL**: https://git.typo3.org/services/t3o-sites/typo3.org/typo3.org
 
-**Branch Strategy**: 
+**Branch Strategy**:
+
 - Main branch: ``develop``
 - Feature branches: ``feature/issue-number-description``
 
@@ -31,6 +32,7 @@ Project Description
 typo3.org serves as the main community hub providing:
 
 **Core Features**
+
 - Community news and announcements
 - Event listings and management
 - Security bulletins and advisories
@@ -39,6 +41,7 @@ typo3.org serves as the main community hub providing:
 - Community member profiles
 
 **Target Audience**
+
 - TYPO3 developers and integrators
 - Agency owners and decision makers
 - Community members and contributors
@@ -52,6 +55,7 @@ Technical Details
 **Database**: MariaDB
 
 **Key Extensions**
+
 - ``t3olayout``: Common layout and styling
 - ``filefill``: Asset loading from production
 - ``news``: News and announcement system
@@ -95,16 +99,19 @@ Development Guidelines
 ======================
 
 **Frontend Development**
+
 - Build assets: ``ddev build-frontend`` (DDEV) or ``npm run build --prefix=vendor/t3o/t3olayout/Build/``
 - CSS/SCSS files located in ``vendor/t3o/t3olayout/Build/``
 - JavaScript files in the same directory structure
 
 **Content Management**
+
 - News articles: Use the news extension
-- Events: Use the events2 extension  
+- Events: Use the events2 extension
 - Pages: Standard TYPO3 page management
 
 **Testing**
+
 - Test all changes locally before creating merge requests
 - Verify responsive design on different screen sizes
 - Check cross-browser compatibility
@@ -114,18 +121,21 @@ Common Development Tasks
 ========================
 
 **Adding News Articles**
+
 - Backend → Web → List → News folder
 - Create new news record
 - Set publication date and author
 - Add categories and tags as needed
 
 **Managing Events**
+
 - Backend → Web → List → Events folder
 - Create new event record
 - Set location, date, and time
 - Configure registration if applicable
 
 **Updating Content**
+
 - Most content can be edited directly in the backend
 - Static content may require template changes
 - Images should be optimized for web use
@@ -134,16 +144,19 @@ Special Considerations
 ======================
 
 **Asset Management**
+
 - Use filefill for production assets
 - Optimize images before upload
 - Use appropriate file formats (WebP when possible)
 
 **Performance**
+
 - Enable caching in production
 - Monitor database query performance
 - Optimize images and assets
 
 **Security**
+
 - Keep TYPO3 core and extensions updated
 - Follow TYPO3 security best practices
 - Monitor security bulletins
@@ -152,11 +165,13 @@ Known Issues & Solutions
 ========================
 
 **Common Problems**
+
 - Asset loading issues → Check filefill configuration
 - Database connection errors → Verify credentials in additional.php
 - Frontend build failures → Clear npm cache and rebuild
 
 **Performance Issues**
+
 - Slow page loads → Check database queries and caching
 - Large images → Optimize and use appropriate formats
 - Memory issues → Increase PHP memory limit if needed
@@ -165,11 +180,13 @@ Getting Help
 ============
 
 **Resources**
+
 - Project-specific issues: Repository issue tracker
 - General questions: TYPO3 Slack #typo3-org
 - TYPO3 documentation: https://docs.typo3.org/
 
 **Contacts**
+
 - Project maintainers: See repository contributors
 - General T3O team: Contact via Slack
 

--- a/Documentation/Projects/VotingTypo3Org/Index.rst
+++ b/Documentation/Projects/VotingTypo3Org/Index.rst
@@ -210,7 +210,7 @@ Getting Help
 **Project Support**
 
 - Repository issues: Use project issue tracker (when available)
-- General questions: TYPO3 Slack #typo3-org
+- General questions: TYPO3 Slack #t3o-team
 - Development support: Contact project maintainers
 
 **Technical Resources**

--- a/Documentation/Projects/VotingTypo3Org/Index.rst
+++ b/Documentation/Projects/VotingTypo3Org/Index.rst
@@ -19,13 +19,15 @@ Repository Information
 
 **Repository URL**: *To be provided*
 
-**Branch Strategy**: 
+**Branch Strategy**:
+
 - Main branch: ``develop``
 - Feature branches: ``feature/issue-number-description``
 
 **Workflow**: Follow the standard :doc:`../../Workflow/Index`
 
 **Access Requirements**
+
 - Standard GitLab access
 - TYPO3.org account required
 
@@ -35,6 +37,7 @@ Project Description
 The TYPO3 Community Voting Platform provides:
 
 **Core Features**
+
 - Community voting on important decisions
 - Ballot creation and management
 - Voting process administration
@@ -43,6 +46,7 @@ The TYPO3 Community Voting Platform provides:
 - Voting history and archives
 
 **Target Audience**
+
 - TYPO3 community members
 - TYPO3 Association members
 - Community decision makers
@@ -56,11 +60,13 @@ Technical Details
 **Database**: MariaDB
 
 **Key Extensions**
+
 - ``t3olayout``: Common layout and styling
 - ``filefill``: Asset loading from production
 - Custom voting extensions for ballot management
 
 **Special Requirements**
+
 - None beyond standard TYPO3 setup
 
 Local Development Setup
@@ -100,24 +106,28 @@ Development Guidelines
 ======================
 
 **Voting System Development**
+
 - Secure voting mechanisms
 - Anonymous voting options
 - Audit trail maintenance
 - Result calculation accuracy
 
 **Frontend Development**
+
 - Build assets: ``ddev build-frontend`` (DDEV)
 - User-friendly voting interfaces
 - Clear result visualization
 - Mobile-responsive design
 
 **Backend Development**
+
 - Ballot creation and management
 - User verification systems
 - Vote counting and validation
 - Administrative interfaces
 
 **Security Considerations**
+
 - Vote integrity protection
 - User authentication security
 - Prevention of multiple voting
@@ -127,18 +137,21 @@ Common Development Tasks
 ========================
 
 **Ballot Management**
+
 - Create new voting ballots
 - Configure voting options
 - Set voting periods and deadlines
 - Manage voter eligibility
 
 **Voting Process**
+
 - User registration and verification
 - Voting interface development
 - Progress tracking and notifications
 - Result calculation and display
 
 **Administration**
+
 - User management and permissions
 - Voting statistics and analytics
 - Archive management
@@ -148,24 +161,28 @@ Special Considerations
 ======================
 
 **Security & Integrity**
+
 - Vote anonymity protection
 - Secure ballot storage
 - Audit trail maintenance
 - Protection against manipulation
 
 **User Experience**
+
 - Clear voting instructions
 - Intuitive interface design
 - Accessibility compliance
 - Mobile device support
 
 **Performance**
+
 - Handle high concurrent voting loads
 - Efficient result calculations
 - Optimized database queries
 - Caching for result displays
 
 **Compliance**
+
 - Data protection regulations
 - Voting process transparency
 - Record retention policies
@@ -175,12 +192,14 @@ Known Issues & Solutions
 ========================
 
 **Common Problems**
+
 - Authentication issues → Check TYPO3.org account integration
 - Voting period errors → Verify timezone configurations
 - Result calculation errors → Check vote counting algorithms
 - Performance during high load → Optimize database and caching
 
 **Development Specific**
+
 - Testing voting scenarios → Use development/staging data
 - Database synchronization → Follow standard sync procedures
 - Asset loading → Verify filefill configuration
@@ -189,16 +208,19 @@ Getting Help
 ============
 
 **Project Support**
+
 - Repository issues: Use project issue tracker (when available)
 - General questions: TYPO3 Slack #typo3-org
 - Development support: Contact project maintainers
 
 **Technical Resources**
+
 - TYPO3 documentation: https://docs.typo3.org/
 - Security best practices: TYPO3 security guidelines
 - Voting system design: Community governance documentation
 
 **Contacts**
+
 - Project maintainers: To be identified
 - TYPO3 Association: For voting process questions
 
@@ -210,11 +232,13 @@ Development Status
    filefill configuration will be provided once available.
 
 **What's Available**
+
 - Project concept and requirements
 - Technical specifications
 - Development guidelines
 
 **Coming Soon**
+
 - Repository access
 - Database dumps
 - Detailed configuration

--- a/Documentation/Workflow/Index.rst
+++ b/Documentation/Workflow/Index.rst
@@ -163,5 +163,5 @@ Getting help
 If you encounter problems:
 
 - Check the :doc:`../FAQ/Index` for common issues
-- Ask in the TYPO3 Slack #typo3-org channel
+- Ask in the TYPO3 Slack #t3o-team or #t3o-ter-team channel
 - Contact project maintainers directly

--- a/Documentation/Workflow/Index.rst
+++ b/Documentation/Workflow/Index.rst
@@ -38,7 +38,7 @@ To solve this, log in to https://typo3.org/ once.
    Only users with **Maintainer** status can merge into ``develop`` and ``main`` branches.
    All other contributors must create merge requests for review.
 
-General Workflow
+General workflow
 ================
 
 .. rst-class:: bignums
@@ -86,7 +86,7 @@ Issue Workflow (Contributors)
    - Remove "Draft:" when ready for maintainer review
    - Add clear description of changes and testing done
 
-Coding Standards
+Coding standards
 ================
 
 Follow TYPO3 Core coding standards:
@@ -122,7 +122,7 @@ Merge Request Workflow (Maintainers)
 
 **Note for Contributors**: You cannot merge your own requests. A maintainer must review and merge all contributions.
 
-Deployment Process
+Deployment process
 ==================
 
 After successful merge to the main branch:
@@ -157,7 +157,7 @@ Branch Strategy & Permissions
 .. warning::
    Direct pushes to ``develop`` and ``main`` are restricted to maintainers only.
 
-Getting Help
+Getting help
 ============
 
 If you encounter problems:

--- a/Documentation/Workflow/Index.rst
+++ b/Documentation/Workflow/Index.rst
@@ -18,22 +18,24 @@ Prerequisites
 =============
 
 **GitLab Account**
-Before you can contribute, you need a GitLab account that corresponds to your TYPO3.org username. 
+Before you can contribute, you need a GitLab account that corresponds to your TYPO3.org username.
 You can manage your TYPO3.org account at `my.typo3.org <https://my.typo3.org/>`_.
 
 **Access Requirements**
+
 - For most projects: TYPO3.org account with GitLab access
 - For **extensions.typo3.org (TER)**: Additional signed NDA required due to GDPR (user data protection)
 
-If you don't have access to GitLab, the reason might be that your username is not present in the LDAP environment. 
+If you don't have access to GitLab, the reason might be that your username is not present in the LDAP environment.
 To solve this, log in to https://typo3.org/ once.
 
 **User Roles & Permissions**
+
 - **Contributors**: Can create feature branches, push commits, and create merge requests
 - **Maintainers**: Can merge into ``develop`` and ``main`` branches, review and approve merge requests
 
 .. important::
-   Only users with **Maintainer** status can merge into ``develop`` and ``main`` branches. 
+   Only users with **Maintainer** status can merge into ``develop`` and ``main`` branches.
    All other contributors must create merge requests for review.
 
 General Workflow
@@ -77,8 +79,8 @@ Issue Workflow (Contributors)
    - Test your changes thoroughly
    - Ensure your branch stays up-to-date with ``develop``
 
-#. **Create Merge Request**: 
-   
+#. **Create Merge Request**:
+
    - Target: ``develop`` branch (never directly to ``main``)
    - Mark as "Draft" while work is in progress
    - Remove "Draft:" when ready for maintainer review
@@ -109,7 +111,7 @@ Merge Request Workflow (Maintainers)
 #. **Local Testing**: Test the code locally on your development environment
 
 #. **Approval Process**:
-   
+
    - If everything is okay: Approve and merge into ``develop``
    - If improvements are needed: Request changes and assign back to author
    - Ensure all tests pass and code quality standards are met
@@ -133,15 +135,18 @@ Branch Strategy & Permissions
 =============================
 
 **Protected Branches**
-- **``main``**: Production branch - **Maintainers only**
-- **``develop``**: Development branch - **Maintainers only**
-- **``master``**: For extensions - **Maintainers only** (legacy naming)
+
+- ``main``: Production branch - Maintainers only
+- ``develop``: Development branch - Maintainers only
+- ``master``: For extensions - Maintainers only (legacy naming)
 
 **Contributor Branches**
+
 - **Feature branches**: ``feature/issue-number-description`` - Contributors can create and push
 - **Hotfix branches**: ``hotfix/description`` - For critical fixes
 
 **Merge Flow**
+
 .. rst-class:: bignums
 
 #. Contributors create feature branches from ``develop``

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -14,7 +14,7 @@
                typo3-core-preferred="stable"
                interlink-shortcode="t3org"
     />
-    <project title="t3o team"
+    <project title="T3O Team"
              release="2.0"
              version="2.0"
              copyright="since ever by the authors"/>


### PR DESCRIPTION
## Summary

Comprehensive documentation audit and fixes addressing multiple categories of issues.

### Critical Fixes (Would Break Functionality)
- **Project ID consistency**: Changed project-id from `5` to `133` in:
  - `Manual/Index.rst` database URLs
  - `FAQ/Index.rst` database URL
  - `Typo3Org/Index.rst` database dump URL
- **Branch name fix**: Changed `auth.json` codesnippet branch from `"main"` to `"develop"` to match actual CI/CD artifact location
- **Literalinclude conversion**: Converted inline `auth.json` in Manual setup to use `literalinclude` directive

### Moderate Fixes (Consistency)
- **Slack channel correction**: Updated all docs to use correct channels:
  - `#t3o-team` for typo3.org, my.typo3.org, voting.typo3.org support
  - `#t3o-ter-team` for extensions.typo3.org support
- **Node.js version update**: Changed from Node.js 14 (EOL April 2023) to Node.js 18 LTS across all files
- **Docker link update**: Changed outdated "Community Edition" link to current Docker Desktop URL

### Previous Fixes (from earlier commits)
- Fixed RST list formatting (empty lines before nested lists)
- Converted filefill config to use `literalinclude`
- Fixed 14 Title Case headings to sentence case
- Fixed `guides.xml` project title capitalization

## Validation
All changes validated with `render-guides --fail-on-log` - no errors or warnings.

## Files Changed
- `Documentation/FAQ/Index.rst`
- `Documentation/LocalEnvironment/Ddev/Index.rst`
- `Documentation/LocalEnvironment/Index.rst`
- `Documentation/LocalEnvironment/Manual/Index.rst`
- `Documentation/LocalEnvironment/_codesnippets/auth.json`
- `Documentation/Projects/Typo3Org/Index.rst`
- `Documentation/Projects/ExtensionsTypo3Org/Index.rst`
- `Documentation/Projects/MyTypo3Org/Index.rst`
- `Documentation/Projects/VotingTypo3Org/Index.rst`
- `Documentation/Projects/Index.rst`
- `Documentation/Workflow/Index.rst`
- `Documentation/guides.xml`